### PR TITLE
FF: Don't append whisper to transcribers if using an older psychopy

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,7 +5,7 @@ on: push
 jobs:
   build:
     name: Build docs
-    runs-on: macos-11
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,6 +12,7 @@ jobs:
         environment: pypi
         permissions:
           id-token: write
+          contents: write 
         steps:
         - uses: actions/checkout@master
 
@@ -27,6 +28,14 @@ jobs:
         - name: Build
           run: |
             python -m build
+                
+        - name: Attach binaries
+          if: startsWith(github.ref, 'refs/tags/')
+          uses: softprops/action-gh-release@v2
+          with:
+            token: ${{ secrets.GITHUB_TOKEN }}
+            files: |
+              dist/*
         
         - name: Upload to PyPi
           if: startsWith(github.ref, 'refs/tags/')

--- a/psychopy_whisper/components/whisperBackend.py
+++ b/psychopy_whisper/components/whisperBackend.py
@@ -9,8 +9,3 @@ from psychopy.experiment.components.microphone import MicrophoneComponent
 # register whisper backend with MicrophoneComponent
 if hasattr(MicrophoneComponent, "localTranscribers"):
     MicrophoneComponent.localTranscribers['OpenAI Whisper'] = "Whisper"
-else:
-    # if PsychoPy version predates this attribute (<2024.2.0), there should be a global instead
-    from psychopy.experiment.components.microphone import localTranscribers, allTranscribers
-    localTranscribers['OpenAI Whisper'] = "Whisper"
-    allTranscribers['OpenAI Whisper'] = "Whisper"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,19 @@ dependencies = [
   "typing-extensions",
 ]
 
+[project.optional-dependencies]
+# dependencies for building the docs
+docs = [
+  "psychopy",
+  "sphinx",
+  "furo",
+]
+# dependencies for running the test suite
+tests = [
+  "psychopy",
+  "pytest",
+]
+
 [tool.setuptools.packages.find]
 where = ["",]
 


### PR DESCRIPTION
I put in a fallback for older versions but actually it's better to do nothing - because `"Whisper"` was hardcoded in as an option, if we append it via the new method it appears twice.